### PR TITLE
FEAT: Query Optimisation

### DIFF
--- a/src/app/(main)/feed/[postId]/page.tsx
+++ b/src/app/(main)/feed/[postId]/page.tsx
@@ -9,7 +9,7 @@ import { Separator } from '@/components/ui/separator'
 import { api } from '@/trpc/react'
 import CommentView from '../../../_components/comment'
 import CommentInput from '../../../_components/new-comment'
-import Post from '../../../_components/post'
+import PostComponent from '../../../_components/post'
 import ArrowLeftIcon from '../../../assets/icons/arrow-left-icon'
 
 export default function PostDetails() {
@@ -17,23 +17,22 @@ export default function PostDetails() {
   const router = useRouter()
   const { userId } = useAuth()
 
-  const postsQuery = api.post.getOne.useQuery({ id: postId as string })
-  const commentsQuery = api.comment.getAllByPost.useQuery({ postId: postId as string })
+  const newPostsQuery = api.post.getOneWithComments.useQuery({ id: postId as string })
 
   const onShowPostQueryError = useCallback(
     async (error: string) => {
-      if (postsQuery.error) {
+      if (newPostsQuery.error) {
         toast.error(error)
       }
     },
-    [postsQuery.error],
+    [newPostsQuery.error],
   )
 
   useEffect(() => {
-    if (postsQuery.error) {
-      void onShowPostQueryError(postsQuery.error.message)
+    if (newPostsQuery.error) {
+      void onShowPostQueryError(newPostsQuery.error.message)
     }
-  }, [onShowPostQueryError, postsQuery.error])
+  }, [onShowPostQueryError, newPostsQuery.error])
 
   return (
     <div className='w-full'>
@@ -49,13 +48,13 @@ export default function PostDetails() {
       </button>
 
       <div className='mt-6'>
-        {postsQuery.data ? <Post post={postsQuery.data} /> : ''}
+        {newPostsQuery.data ? <PostComponent post={newPostsQuery.data} /> : ''}
 
         {userId ? (
           <CommentInput
             onSuccess={() => {
-              void postsQuery.refetch()
-              void commentsQuery.refetch()
+              void newPostsQuery.refetch()
+              // void commentsQuery.refetch()
             }}
           />
         ) : null}
@@ -65,8 +64,8 @@ export default function PostDetails() {
         <div>
           <h3 className='text-sm font-medium leading-5 text-gray-800'>All comments</h3>
 
-          {commentsQuery.data?.map((comment) => (
-            <CommentView key={comment.id} comment={comment} parentComment />
+          {newPostsQuery.data?.comments?.map((comment) => (
+            <CommentView key={comment.id} comment={comment} parentComment onRefresh={newPostsQuery.refetch} />
           ))}
         </div>
       </div>

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -2,12 +2,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { headers } from 'next/headers'
 
+import { env } from '@/env'
 import { db } from '@/server/db'
 import { usersTable } from '@/server/db/schema'
 
 export async function POST(req: Request) {
   // You can find this in the Clerk Dashboard -> Webhooks -> choose the webhook
-  const WEBHOOK_SECRET = 'whsec_KVtIl+Lqs3OroqYittPcPJQsZONIFssD'
+  const WEBHOOK_SECRET = env.CLERK_SECRET_KEY
 
   if (!WEBHOOK_SECRET) {
     throw new Error('Please add WEBHOOK_SECRET from Clerk Dashboard to .env or .env.local')

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { ClerkProvider } from '@clerk/nextjs'
 import { Toaster } from '@/components/ui/sonner'
 import { TRPCReactProvider } from '@/trpc/react'
 
-export const runtime = 'edge'
+export const runtime = 'nodejs'
 
 const inter = Inter({
   subsets: ['latin'],

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -20,6 +20,7 @@ export const postsTable = createTable('posts', {
 
 export const postTableRelations = relations(postsTable, ({ one, many }) => ({
   comments: many(commentsTable),
+  votes: many(votesTable),
   user: one(usersTable, {
     fields: [postsTable.userId],
     references: [usersTable.id],
@@ -44,10 +45,18 @@ export const commentsTable = createTable('comments', {
   updatedAt: timestamp('updatedAt').onUpdateNow(),
 })
 
-export const commentsTableRelations = relations(commentsTable, ({ one }) => ({
+export const commentsTableRelations = relations(commentsTable, ({ one, many }) => ({
   post: one(postsTable, {
     fields: [commentsTable.postId],
     references: [postsTable.id],
+  }),
+  parent: one(commentsTable, {
+    relationName: 'parent', // Relation name to disambiguate the self-referencing relation
+    fields: [commentsTable.commentId],
+    references: [commentsTable.id],
+  }),
+  nestedComments: many(commentsTable, {
+    relationName: 'parent', // Relation name to disambiguate the self-referencing relation
   }),
   user: one(usersTable, {
     fields: [commentsTable.userId],
@@ -72,6 +81,13 @@ export const votesTable = createTable('votes', {
     .notNull(),
   updatedAt: timestamp('updatedAt').onUpdateNow(),
 })
+
+export const votesTableRelations = relations(votesTable, ({ one }) => ({
+  post: one(postsTable, {
+    fields: [votesTable.postId],
+    references: [postsTable.id],
+  }),
+}))
 
 export type Vote = InferSelectModel<typeof votesTable>
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -51,12 +51,12 @@ export const commentsTableRelations = relations(commentsTable, ({ one, many }) =
     references: [postsTable.id],
   }),
   parent: one(commentsTable, {
-    relationName: 'parent', // Relation name to disambiguate the self-referencing relation
+    relationName: 'parent',
     fields: [commentsTable.commentId],
     references: [commentsTable.id],
   }),
   nestedComments: many(commentsTable, {
-    relationName: 'parent', // Relation name to disambiguate the self-referencing relation
+    relationName: 'parent',
   }),
   user: one(usersTable, {
     fields: [commentsTable.userId],

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,5 +1,6 @@
 import { type CommentBase, type User } from '@/server/db/schema'
 
 export type Comment = CommentBase & {
-  user: User
+  user: User | null
+  nestedComments?: Comment[]
 }

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,5 +1,7 @@
 import { type PostBase, type User } from '@/server/db/schema'
+import { type Comment } from './comment'
 
 export type Post = PostBase & {
+  comments?: Comment[]
   user: User
 }


### PR DESCRIPTION
### Description

This PR is to show a recommended optimisation on the fetch for posts, comments and nested comments.
It shows an alternative to implement nested query with Drizzle ORM.

An important point is that Drizzle ORM don't support recursive query, so it is needed for an algorithm solution on the router/controller level to, recursively, check for more in-depth nested comments or add a limit and implement another solution like a button to load more nested comments of a comment.

